### PR TITLE
Fix wrap key in quotes if it contains special characters

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ If you have something like this:
             "age": 19,
         }
     ],
-    "favorite_movie": null
+    "favorite_movie": null,
+    "(some)%wild;key": 5
 }
 ```
 
@@ -36,7 +37,7 @@ And you want something like this:
   length_in_meters = 1.8;
   best_friends = [
     {
-      name = "Bob";
+      name = "bob";
       age = 19;
     }
     {
@@ -45,6 +46,7 @@ And you want something like this:
     }
   ];
   favorite_movie = null;
+  "(some)%wild;key" = 5;
 }
 ```
 

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -60,10 +60,12 @@ data ObjectAttribute = ObjectAttribute String Value
 instance Show ObjectAttribute where
   show (ObjectAttribute name value) = name ++ " = " ++ show value
 
+shouldQuoteKey :: String -> Bool
+shouldQuoteKey key = not (all (\c -> isAlphaNum c || c == '_' || c == '-') key)
+
 showObjectAttr :: Int -> ObjectAttribute -> String
 showObjectAttr i (ObjectAttribute name value) = let
-  startsWithDigit = isDigit $ head name
-  newName = if startsWithDigit
+  newName = if shouldQuoteKey name
     then "\"" ++ name ++ "\""
     else name
   in indentSpace i ++ newName ++ " = " ++ (showAsNix i value) ++ ";"


### PR DESCRIPTION
There are many special characters that Nix treats specially and that may
cause trouble if found inside the key of an attribute set.

Eg. if a key contains a dot, Nix will interpret it as a nested attribute
set. Or if a key contains a slash, Nix recognizes it as Path. Also there
are semicolons, braces etc.

Thus, this PR introduces a condition to add quotes around the key if
any other sign apart from [a-zA-Z0-9-_] is found.