### PR TITLE
Accept files name as command line argument and enable streaming

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,18 +51,10 @@ And you want something like this:
 You can do so by enabling nix flakes and run the following command in your shell:
 
 ```shell
-nix run github:sempruijs/json2nix
+nix run github:sempruijs/json2nix [inputfile] [output]
 ```
 
-This will install the required tools.
-json2nix will ask two questions:
-
-1. Choose a file path.
-This could be something like: ```config.json```.
-
-2. Choose a file name for the new nix file.
-You can type something or hit enter for the suggestion.
-This would be something like: ```config.nix```
+Both arguments may be omitted or set to "-" in which case json2nix will read from stdin resp. write to stdout.
 
 ## Contributing
 


### PR DESCRIPTION
This commit changes the behavior of the program in such a way that it accepts input and output filenames as command line arguments instead of prompting for them. This makes usage in scripts easier.

Both arguments may be omitted or set to "-" in which case the json2nix will read from stdin resp. write to stdout.