### PR TITLE
Add yaml2nix and toml2nix

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # json2nix
 
-A json to nix converter written in Haskell.
+A json/yaml/toml to nix converter written in Haskell.
 You can use this easily with a flake.
 Unformatted json is also supported.
 
@@ -63,6 +63,19 @@ This could be something like: ```config.json```.
 2. Choose a file name for the new nix file.
 You can type something or hit enter for the suggestion.
 This would be something like: ```config.nix```
+
+## YAML and TOML
+
+By virtue of [yq](https://github.com/kislyuk/yq), this flake also contains two packages `yaml2nix` and `toml2nix` that can be used just like `json2nix`:
+
+```shell
+nix run github:sempruijs/json2nix#yaml2nix [inputfile] [output]
+```
+
+```shell
+nix run github:sempruijs/json2nix#toml2nix [inputfile] [output]
+```
+
 
 ## Contributing
 

--- a/flake.nix
+++ b/flake.nix
@@ -54,6 +54,32 @@
 
         # haskell-flake doesn't set the default package, but you can do it here.
         packages.default = self'.packages.json2nix;
+        packages.yaml2nix = pkgs.writeShellScriptBin "yaml2nix" ''
+          cmd="${pkgs.yq}/bin/yq"
+          if [ -n "$1" ] && [ "$1" != "-" ]; then
+            cmd="$cmd \"$1\""
+          fi
+
+          cmd="$cmd | ${self'.packages.json2nix}/bin/json2nix"
+          if [ -n "$2" ]; then
+            cmd="$cmd - \"$2\""
+          fi
+
+          eval $cmd
+        '';
+        packages.toml2nix = pkgs.writeShellScriptBin "toml2nix" ''
+          cmd="${pkgs.yq}/bin/tomlq"
+          if [ -n "$1" ] && [ "$1" != "-" ]; then
+            cmd="$cmd \"$1\""
+          fi
+
+          cmd="$cmd | ${self'.packages.json2nix}/bin/json2nix"
+          if [ -n "$2" ]; then
+            cmd="$cmd - \"$2\""
+          fi
+
+          eval $cmd
+        '';
       };
     };
 }

--- a/json2nix.cabal
+++ b/json2nix.cabal
@@ -9,7 +9,7 @@ build-type:      Simple
 common warnings
     ghc-options: -Wall
 
-executable example
+executable json2nix
     import:           warnings
     main-is:          Main.hs
     build-depends:    base,


### PR DESCRIPTION
This commit adds two additional packages yaml2nix and toml2nix to the
flake in order to convert yaml and toml data structures to Nix using yq
and tomlq of the yq package. Each command mimicks the behevior of
json2nix in regard to the command line arguments.