### PR TITLE
fix name for executable

### DIFF
--- a/json2nix.cabal
+++ b/json2nix.cabal
@@ -9,7 +9,7 @@ build-type:      Simple
 common warnings
     ghc-options: -Wall
 
-executable example
+executable json2nix
     import:           warnings
     main-is:          Main.hs
     build-depends:    base,


### PR DESCRIPTION
I added the flake to my config but the executable is only available under the name "example" in the nix store
i think this pr fixes it